### PR TITLE
Configurable mime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can see this in action by looking into the [basic example](examples/basic)
 * `bundleOpts`: (Object, default: `{ format: 'iife' }`)
 * `debug`: (Bool, default: `false`)
 * `maxAge`: (Integer, default: `0`)
+* `type`: (String, default: `javascript`). MIME type of served bundles. Can be anything, e.g. `application/javascript`
 
 ## Troubleshooting
 ### Different module file extensions than `.js`

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const defaults = {
   serve: false, // or 'on-compile' or true. 'on-compile' has the benefit
                 // that the bundle which is already in memory will be
                 // written directly into the response
+  type: 'javascript',
   rollupOpts: {},
   bundleOpts: { format: 'iife' },
   debug: false,
@@ -111,7 +112,7 @@ class ExpressRollup {
       } else if (opts.serve === true) {
         /** serves js code from cache by ourselves */
         res.status(200)
-          .type('javascript')
+          .type(opts.type)
           .set('Cache-Control', `max-age=${opts.maxAge}`)
           .sendFile(jsPath, err => {
             if (err) {
@@ -143,7 +144,7 @@ class ExpressRollup {
       /** serves js code by ourselves */
       this.log('Serving', 'ourselves');
       res.status(200)
-        .type('javascript')
+        .type(opts.type)
         .set('Cache-Control', `max-age=${opts.maxAge}`)
         .send(bundled.code);
     } else {


### PR DESCRIPTION
Basically because I prefer `application/javascript` over `javascript`.

I've added it as an option keeping `javascript` as default for compatibility reasons.